### PR TITLE
Fikser denne buggen:

### DIFF
--- a/src/content/parts/utbetaling/NyUtbetalingModal.tsx
+++ b/src/content/parts/utbetaling/NyUtbetalingModal.tsx
@@ -108,8 +108,12 @@ const defaultUtbetaling: Utbetaling = {
 };
 
 const NyUtbetalingModal: React.FC<Props> = (props: Props) => {
-  const [modalUtbetaling, setModalUtbetaling] =
-    useState<Utbetaling>(initialUtbetaling);
+
+  const utbetaling: Utbetaling = initialUtbetaling;
+  utbetaling.utbetalingsreferanse = generateFilreferanseId()
+
+  const [modalUtbetaling, setModalUtbetaling] = useState<Utbetaling>(utbetaling);
+
   const [kontonummerLabelPlaceholder, setKontonummerLabelPlaceholder] =
     useState("Kontonummer (Ikke satt)");
 


### PR DESCRIPTION
Under generering av ny utbetaling så er utbetalingsreferansen statisk, som forårsaker at utbetalingen blir sett på som duplikat og det vises bare 1 i innsyn og modia. Mer informasjon i: https://trello.com/c/CoS07oOZ/117-feil-med-utbetalinger-i-fagsystem-mock